### PR TITLE
Allow strings in gettext calls with context to be replaced.

### DIFF
--- a/say-what-frontend.php
+++ b/say-what-frontend.php
@@ -20,6 +20,7 @@ class say_what_frontend {
 			$this->replacements[$value['domain']][$value['orig_string']] = $value['replacement_string'];
 		}
 		add_filter ( 'gettext', array ( $this, 'gettext' ), 10, 3 );
+		add_filter ( 'gettext_with_context', array( $this, 'gettext_context' ), 10, 4 );
 	}
 
     /**
@@ -33,4 +34,10 @@ class say_what_frontend {
 		}
 	}
 
+	/**
+	 * Route gettext calls with context to the main replacement method.
+	 */
+	function gettext_context( $translated, $original, $context, $domain ) {
+		return $this->gettext( $translated, $original, $domain );
+	}
 }


### PR DESCRIPTION
This doesn't use the context argument in any meaningful way. Context
can be added as a separate field in the admin in the future, but that
will also require a schema change to the database. See issue #7
