### PR TITLE
Improve I18N Issues

### DIFF
--- a/html/say-what-admin-addedit.php
+++ b/html/say-what-admin-addedit.php
@@ -1,8 +1,8 @@
 <div class="wrap">
 	<div id="icon-tools" class="icon32"></div>
-	<h2><?php _e( 'Text changes', 'say-what' ); ?></h2>
+	<h2><?php esc_html_e( 'Text changes', 'say-what' ); ?></h2>
 
-	<p><?php _e( "Fill in the details of the original translatable string, the string's text domain, and the string you would like to use instead. For more information check out the <a href='https://plugins.leewillis.co.uk/doc_post/adding-string-replacement/' target='_blank' rel='noopener noreferrer'>getting started guide</a>." ); ?></p>
+	<p><?php printf(esc_html__( 'Fill in the details of the original translatable string, the string\'s text domain, and the string you would like to use instead. For more information check out the %1$sgetting started guide%2$s.', 'say-what' ),'<a href="https://plugins.leewillis.co.uk/doc_post/adding-string-replacement/" target="_blank" rel="noopener noreferrer">','</a>'); ?></p>
 	<form action="tools.php?page=say_what_admin&amp;say_what_action=addedit" method="post">
 		<input type="hidden" name="say_what_save" value="1">
 		<?php wp_nonce_field( 'swaddedit', 'nonce' ); ?>
@@ -10,19 +10,19 @@
 			<input type="hidden" name="say_what_string_id" value="<?php echo esc_attr( htmlspecialchars( $replacement->string_id ) ); ?>">
 		<?php endif; ?>
 		<p>
-			<label for="say_what_orig_string"><?php _e( 'Original string', 'say-what' ); ?></label><br/>
+			<label for="say_what_orig_string"><?php esc_html_e( 'Original string', 'say-what' ); ?></label><br/>
 			<textarea class="say_what_orig_string" name="say_what_orig_string" rows="1" cols="120"><?php echo esc_textarea( $replacement->orig_string ); ?></textarea>
 		</p>
 		<p>
-			<label for="say_what_domain"><?php _e( 'Text domain', 'say-what' ); ?></label> <a href="https://plugins.leewillis.co.uk/doc_post/adding-string-replacement/" target="_blank" rel="noopener noreferrer"><i class="dashicons dashicons-info">&nbsp;</i></a><br/>
+			<label for="say_what_domain"><?php esc_html_e( 'Text domain', 'say-what' ); ?></label> <a href="https://plugins.leewillis.co.uk/doc_post/adding-string-replacement/" target="_blank" rel="noopener noreferrer"><i class="dashicons dashicons-info">&nbsp;</i></a><br/>
 			<input type="text" name="say_what_domain" size="30" value="<?php echo esc_attr( htmlspecialchars( $replacement->domain ) ); ?>"><br/>
 		</p>
 		<p>
-			<label for="say_what_context"><?php _e( 'Text context', 'say-what' ); ?></label> <a href="https://plugins.leewillis.co.uk/doc_post/replacing-wordpress-strings-context/" target="_blank" rel="noopener noreferrer"><i class="dashicons dashicons-info">&nbsp;</i></a><br/>
+			<label for="say_what_context"><?php esc_html_e( 'Text context', 'say-what' ); ?></label> <a href="https://plugins.leewillis.co.uk/doc_post/replacing-wordpress-strings-context/" target="_blank" rel="noopener noreferrer"><i class="dashicons dashicons-info">&nbsp;</i></a><br/>
 			<input type="text" name="say_what_context" size="30" value="<?php echo esc_attr( htmlspecialchars( $replacement->context ) ); ?>"><br/>
 		</p>
 		<p>
-			<label for="say_what_replacement_string"><?php _e( 'Replacement string', 'say-what' ); ?></label><br/>
+			<label for="say_what_replacement_string"><?php esc_html_e( 'Replacement string', 'say-what' ); ?></label><br/>
 			<textarea class="say_what_replacement_string" name="say_what_replacement_string" cols="120" rows="1"><?php echo esc_textarea( $replacement->replacement_string ); ?></textarea>
 		</p>
 		<p>

--- a/html/say-what-admin-delete.php
+++ b/html/say-what-admin-delete.php
@@ -1,8 +1,8 @@
 <div class="wrap">
 	<div id="icon-tools" class="icon32"></div>
-	<h2><?php _e( 'Text changes', 'say-what' ); ?></h2>
+	<h2><?php esc_html_e( 'Text changes', 'say-what' ); ?></h2>
 
-	<p><?php printf( __( 'Are you sure you want to delete the replacement string for &quot;%s&quot;?', 'say-what' ), esc_html( $replacement->orig_string ) ); ?></p>
+	<p><?php printf(esc_html__( 'Are you sure you want to delete the replacement string for &quot;%s&quot;?', 'say-what' ), esc_html( $replacement->orig_string ) ); ?></p>
 	<p>
-		<a href="tools.php?page=say_what_admin&amp;say_what_action=delete-confirmed&amp;id=<?php echo urlencode( $_GET['id'] ); ?>&amp;nonce=<?php echo urlencode( $_GET['nonce'] ); ?>" class="button"><?php _e( 'Yes', 'say-what' ); ?></a> <a href="tools.php?page=say_what_admin" class="button button-primary"><?php _e( 'No', 'say-what' ); ?></a>
+		<a href="tools.php?page=say_what_admin&amp;say_what_action=delete-confirmed&amp;id=<?php echo urlencode( $_GET['id'] ); ?>&amp;nonce=<?php echo urlencode( $_GET['nonce'] ); ?>" class="button"><?php esc_html_e( 'Yes', 'say-what' ); ?></a> <a href="tools.php?page=say_what_admin" class="button button-primary"><?php esc_html_e( 'No', 'say-what' ); ?></a>
 </div>

--- a/html/say-what-admin-list.php
+++ b/html/say-what-admin-list.php
@@ -14,7 +14,7 @@
             <div class="swp-img-container">
                 <a href="https://ecologi.com/ademtisoftware?gift-trees&amp;r=ademtisoftware" target="_blank" rel="noopener noreferrer nofollow">
                     <img src="<?php echo esc_attr( plugins_url( 'say-what/img/cpw.png' ) ); ?>"
-                         alt="<?php esc_attr_e( 'We\'re a climate positive workforce', 'say-what' ); ?>">
+                         alt="<?php esc_attr_e( "We're a climate positive workforce", 'say-what' ); ?>">
                 </a>
             </div>
             <div class="swp-intro-container">

--- a/html/say-what-admin-list.php
+++ b/html/say-what-admin-list.php
@@ -1,7 +1,7 @@
 <div class="wrap">
     <div id="icon-tools" class="icon32"></div>
-    <h2><?php _e( 'Text changes', 'say-what' ); ?><a href="tools.php?page=say_what_admin&amp;say_what_action=addedit"
-                                                     class="add-new-h2"><?php _e( 'Add New', 'say-what' ); ?></a></h2>
+    <h2><?php esc_html_e( 'Text changes', 'say-what' ); ?><a href="tools.php?page=say_what_admin&amp;say_what_action=addedit"
+                                                     class="add-new-h2"><?php esc_html_e( 'Add New', 'say-what' ); ?></a></h2>
 	<?php
 	$list_table_instance = new SayWhatListTable( $this->settings );
 	$list_table_instance->prepare_items();
@@ -14,64 +14,47 @@
             <div class="swp-img-container">
                 <a href="https://ecologi.com/ademtisoftware?gift-trees&amp;r=ademtisoftware" target="_blank" rel="noopener noreferrer nofollow">
                     <img src="<?php echo esc_attr( plugins_url( 'say-what/img/cpw.png' ) ); ?>"
-                         alt="We're a climate positive workforce">
+                         alt="<?php esc_attr_e( 'We\'re a climate positive workforce', 'say-what' ); ?>">
                 </a>
             </div>
             <div class="swp-intro-container">
-                <p class="swp-intro">Using this plugin on your live site? Please buy the world some trees...</p>
+                <p class="swp-intro"><?php esc_html_e( 'Using this plugin on your live site? Please buy the world some trees...', 'say-what' ); ?></p>
                 <div><a class="button" target="_blank" rel="noopener noreferrer nofollow"
-                        href="https://ecologi.com/ademtisoftware?gift-trees&amp;r=ademtisoftware">Support this free plugin by planting trees</a></div>
+                        href="https://ecologi.com/ademtisoftware?gift-trees&amp;r=ademtisoftware"><?php esc_html_e( 'Support this free plugin by planting trees', 'say-what' ); ?></a></div>
             </div>
             <div class="swp-content-container">
-                <p>It’s now common knowledge that one of the best tools to tackle the climate crisis and keep our
-                    temperatures from rising above 1.5C is to <a
-                            href="https://www.bbc.co.uk/news/science-environment-48870920" target="_blank"
-                            rel="noopener noreferrer nofollow">plant trees</a>.</p>
-                <p>As a business, we already donate a percentage of our profits from premium plugins to global climate
-                    change projects. You're free to use package free of charge, but if you do, please consider <a
-                            target="_blank" rel="noopener noreferrer nofollow"
-                            href="https://ecologi.com/ademtisoftware?gift-trees&amp;r=ademtisoftware">buying the world some trees</a> in return.
-                    You’ll be creating employment for local families and restoring wildlife habitats.</p>
+                <p><?php printf(esc_html__( 'It’s now common knowledge that one of the best tools to tackle the climate crisis and keep our temperatures from rising above 1.5C is to %1$splant trees%2$s.', 'say-what' ),'<a href="https://www.bbc.co.uk/news/science-environment-48870920" target="_blank" rel="noopener noreferrer nofollow">','</a>'); ?></p>
+                <p><?php printf(esc_html__( 'As a business, we already donate a percentage of our profits from premium plugins to global climate change projects. You\'re free to use package free of charge, but if you do, please consider %1$sbuying the world some trees%2$s in return. You’ll be creating employment for local families and restoring wildlife habitats.', 'say-what' ),'<a target="_blank" rel="noopener noreferrer nofollow" href="https://ecologi.com/ademtisoftware?gift-trees&amp;r=ademtisoftware">','</a>'); ?></p>
             </div>
         </div>
         <div class="saywhat-gopro">
             <div>
-                <h2>Go pro today</h2>
+                <h2><?php esc_html_e( 'Go Pro today', 'say-what' ); ?></h2>
                 <hr>
                 <p>
-                    <a href="https://plugins.leewillis.co.uk/downloads/say-what-pro/?utm_source=wporg&amp;utm_medium=plugin&amp;utm_campaign=saywhatproupgrade"
-                       target="_blank" rel="noopener noreferrer">Say What? Pro</a> makes it even easier for you to
-                    change strings:
+                    <?php printf(esc_html__( '%1$sSay What? Pro%2$s makes it even easier for you to change strings:', 'say-what' ),'<a href="https://plugins.leewillis.co.uk/downloads/say-what-pro/?utm_source=wporg&amp;utm_medium=plugin&amp;utm_campaign=saywhatproupgrade" target="_blank" rel="noopener noreferrer">','</a>'); ?>
                 <ul class="ul-disc">
                     <li>
-                        <a href="https://plugins.leewillis.co.uk/doc_post/string-discovery/?utm_source=wporg&amp;utm_medium=plugin&amp;utm_campaign=saywhatproupgrade"
-                           target="_blank" rel="noopener noreferrer">String Discovery</a> and autocomplete - find the
-                        strings you need without diving through code. Works with server-side and Javascript-rendered
-                        strings.
+                        <?php printf(esc_html__( '%1$sString Discovery%2$s and autocomplete - find the strings you need without diving through code. Works with server-side and Javascript-rendered strings.', 'say-what' ),'<a href="https://plugins.leewillis.co.uk/doc_post/string-discovery/?utm_source=wporg&amp;utm_medium=plugin&amp;utm_campaign=saywhatproupgrade"
+                           target="_blank" rel="noopener noreferrer">','</a>'); ?>
                     </li>
                     <li>
-                        <a href="https://plugins.leewillis.co.uk/doc_post/replace-words-across-whole-site/?utm_source=wporg&amp;utm_medium=plugin&amp;utm_campaign=saywhatproupgrade"
-                           target="_blank" rel="noopener noreferrer">Wildcard string replacements</a> - replace
-                        individual words, or fragments
-                        across your whole site.
+                        <?php printf(esc_html__( '%1$sWildcard string replacements%2$s - replace individual words, or fragments across your whole site.', 'say-what' ),'<a href="https://plugins.leewillis.co.uk/doc_post/replace-words-across-whole-site/?utm_source=wporg&amp;utm_medium=plugin&amp;utm_campaign=saywhatproupgrade" target="_blank" rel="noopener noreferrer">','</a>'); ?>
                     </li>
                     <li>
-                        <a href="https://plugins.leewillis.co.uk/doc_post/multi-lingual-string-replacements/?utm_source=wporg&amp;utm_medium=plugin&amp;utm_campaign=saywhatproupgrade"
-                           target="_blank" rel="noopener noreferrer">Multi-lingual support</a> - set different
-                        replacements for different languages.</a></li>
+                        <?php printf(esc_html__( '%1$sMulti-lingual support%2$s - set different replacements for different languages.', 'say-what' ),'<a href="https://plugins.leewillis.co.uk/doc_post/multi-lingual-string-replacements/?utm_source=wporg&amp;utm_medium=plugin&amp;utm_campaign=saywhatproupgrade" target="_blank" rel="noopener noreferrer">','</a>'); ?>
+					</li>
                     <li>
-                        <a href="https://plugins.leewillis.co.uk/doc_post/import-export-string-replacements/?utm_source=wporg&amp;utm_medium=plugin&amp;utm_campaign=saywhatproupgrade">Import
-                            &amp; export</a> your strings between sites.
+                        <?php printf(esc_html__( '%1$sImport &amp; export%2$s your strings between sites.', 'say-what' ),'<a href="https://plugins.leewillis.co.uk/doc_post/import-export-string-replacements/?utm_source=wporg&amp;utm_medium=plugin&amp;utm_campaign=saywhatproupgrade">','</a>'); ?>
                     </li>
-                    <li><em>Improved performance</em> using text-domain-specific filters.</li>
+                    <li><?php printf(esc_html__( '%1$sImproved performance%2$s using text-domain-specific filters.', 'say-what' ),'<em>','</em>'); ?></li>
                 </ul>
                 </p>
-                <p><strong>Upgrade to the Pro version today, and <em>save 15%</em> with the code <code>WPSAYWHAT</code>
-                        at checkout.</strong></p>
+                <p><strong><?php printf(esc_html__( 'Upgrade to the Pro version today, and %1$ssave 15&#37;%2$s with the code %3$sWPSAYWHAT%4$s at checkout.', 'say-what' ),'<em>','</em>','<code>','</code>'); ?></strong></p>
                 <p>
                 <center>
                     <a href="https://plugins.leewillis.co.uk/downloads/say-what-pro/?utm_source=wporg&amp;utm_medium=plugin&amp;utm_campaign=saywhatproupgradebtn"
-                       class="button button-primary" target="_blank" rel="noopener noreferrer">Go Pro now &raquo;</a>
+                       class="button button-primary" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Go Pro now &raquo;', 'say-what' ); ?></a>
                 </center>
                 </p>
             </div>


### PR DESCRIPTION
- Add the correct text domain for the UI string without text domain.
- For security reason, change `<?php _e(` to `<?php esc_html_e(`. Please refer to [this official article](https://developer.wordpress.org/plugins/internationalization/security/).
- Make the UI strings without I18N code translatable.